### PR TITLE
Custom UID and restartable container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ MAINTAINER Knut Ahlers <knut@ahlers.me>
 
 ENV USER share
 ENV PASS changeme
+ENV USER_UID 1000
 
 RUN apt-get update && \
     apt-get install -y openssh-server mcrypt && \

--- a/start.sh
+++ b/start.sh
@@ -1,12 +1,11 @@
 #!/bin/bash
 
-ENC_PASS=$(perl -e 'print crypt($ARGV[0], "password")' ${PASS})
-
 if ( id ${USER} ); then
-  echo "FATAL: User ${USER} already exists"
-  exit 1
+    echo "INFO: User ${USER} already exists"
+else
+    echo "INFO: User ${USER} does not exists, we create it"
+    ENC_PASS=$(perl -e 'print crypt($ARGV[0], "password")' ${PASS})
+    useradd -d /data -m -p ${ENC_PASS} -u ${USER_UID} -s /bin/sh ${USER}
 fi
-
-useradd -d /data -m -p ${ENC_PASS} -u 1000 -s /bin/sh ${USER}
 
 exec /usr/sbin/sshd -D


### PR DESCRIPTION
Hi,

Here are two little changes but useful:
- New `USER_UID` env var if you want to reflect an existing user on a `/data` volume. For example, if you are using `maxexcloo/data` Docker image, the “core” user is created with uid=500.
- Container can be restarted, it won’t exit because user already exists.
